### PR TITLE
changes and adds files to support both windows and mac

### DIFF
--- a/JS_Files/avRecorder.js
+++ b/JS_Files/avRecorder.js
@@ -2,10 +2,10 @@ const { spawn } = require("child_process");
 const Stream = require("stream");
 const path = require('path');
 const fs = require("fs");
+var isWin = process.platform === "win32";
 
 const CHRONOSENSE_ROOT_DIR = path.join(path.resolve(__dirname), '../');
 const FFMPEG_DIR = path.join(CHRONOSENSE_ROOT_DIR, '/ffmpeg/');
-
 
 
 export class AVRecorder {
@@ -106,11 +106,20 @@ export class AVRecorder {
 	 */
 	async postProcessVideoFile() {
 
-		var subprocess = spawn(FFMPEG_DIR.concat("ffmpeg.exe"), [
-			"-i",
-			this.#dirName.concat("raw/").concat(this.#fileName),
-			this.#dirName.concat(this.#fileName.substring(0, this.#fileName.length - 5)).concat(".mp4")
-		], {detached: true});
+		if (!isWin) {
+			spawn("ffmpeg", [
+				"-i",
+				this.#dirName.concat("raw/").concat(this.#fileName),
+				this.#dirName.concat(this.#fileName.substring(0, this.#fileName.length - 5)).concat(".mp4")
+			], {detached: true});
+		}
+		else {
+			spawn(FFMPEG_DIR.concat("ffmpeg.exe"), [
+				"-i",
+				this.#dirName.concat("raw/").concat(this.#fileName),
+				this.#dirName.concat(this.#fileName.substring(0, this.#fileName.length - 5)).concat(".mp4")
+			], {detached: true});
+		}
 
 	}
 

--- a/get_ffmpeg.js
+++ b/get_ffmpeg.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const download = require('download');
 const extract = require('extract-zip');
+var isWin = process.platform === "win32";
 
 const CHRONOSENSE_ROOT_DIR = path.resolve(__dirname);
 const FFMPEG_DIR = path.resolve(CHRONOSENSE_ROOT_DIR, 'ffmpeg');
@@ -15,6 +16,9 @@ const init = async (callback) => {
         await fs.writeFile(FFMPEG_ZIP, await download(FFMPEG_URL));
     }
     */
+    if (!isWin) {
+        return;
+    }
 
     if (!(await fs.pathExists(FFMPEG_DIR))) {
         console.log('downloading ffmpeg to:' + CHRONOSENSE_ROOT_DIR);

--- a/install_helper.js
+++ b/install_helper.js
@@ -1,0 +1,27 @@
+const { exec } = require("child_process");
+var isWin = process.platform === "win32";
+
+const init = async (callback) => {
+    if(isWin){
+        exec('.\\node_modules\\.bin\\electron-rebuild.cmd',
+        (error, stdout, stderr) => {
+            console.log(stdout);
+            console.log(stderr);
+            if (error !== null) {
+                console.log(`exec error: ${error}`);
+            }
+        });
+    }
+    else {
+        exec('./node_modules/.bin/electron-rebuild',
+        (error, stdout, stderr) => {
+            console.log(stdout);
+            console.log(stderr);
+            if (error !== null) {
+                console.log(`exec error: ${error}`);
+            }
+        });
+    }
+}
+
+init();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "main.js",
 	"scripts": {
 		"start": "electron --no-sandbox --use-gl=swiftshader .",
-		"install": ".\\node_modules\\.bin\\electron-rebuild.cmd",
+		"install": "node ./install_helper.js",
 		"postinstall": "node ./get_ffmpeg.js",
 		"package": "electron-packager ."
 	},


### PR DESCRIPTION
adds variable which checks for os to match windows `var isWin = process.platform === "win32";` to both get_ffmpeg.js and avRecorder.js to allow for os specific tweaks - also creates file `install_helper.js` at root which replaces electron rebuild instructions in `package.json` to run the correct commands depending on os

tested on both windows 10 and mac os 11 - ffmpeg is assumed to be prebuilt and found in path for mac