### PR TITLE
fixes device on/off handling to maintain audio source constraints

### DIFF
--- a/JS_Files/camera.js
+++ b/JS_Files/camera.js
@@ -185,9 +185,6 @@ export class Camera {
 				};
 			}
 		}
-		else {
-
-		}
 		
 
 		var stream = null;
@@ -251,7 +248,9 @@ export class Camera {
 	}
 
 	restartCameraStream(audioSelector) {
-		this.stopCameraStream();
+		if(this.#isOn){
+			this.stopCameraStream();
+		}
 		let constraints = {video: false, audio: false};
 		constraints.video = {
 			deviceId: this.#deviceId,
@@ -454,7 +453,7 @@ export class Camera {
 
 		onElement.innerText = "ON";
 		onElement.onclick = () => {
-			this.startCameraStream();
+			this.restartCameraStream(audioSelector);
 		};
 		onElement.classList.add("general-btn");
 		onElement.style.height = "48%";


### PR DESCRIPTION
audio source constraints are only updated on input field (selector) change, but should also be maintained when a device is turned on/off

fixes this by changing on/off handling to route through `restartCameraStream`