### PR TITLE
Deployment bugfix

### DIFF
--- a/JS_Files/avRecorder.js
+++ b/JS_Files/avRecorder.js
@@ -74,7 +74,7 @@ export class AVRecorder {
 		this.#forked = getForkedProcess();
 
 		this.#forked.on('message', (msg) => {
-			console.log('Message from child', msg);
+			// console.log('Message from child', msg);
 			if (msg.child_state == "processing"){
 				decrementVR();
 				incrementVP();

--- a/JS_Files/chronosense.js
+++ b/JS_Files/chronosense.js
@@ -15,7 +15,7 @@ const fixPath = require('fix-path');
 fixPath();
 
 const homeDir = require('os').homedir(); // See: https://www.npmjs.com/package/os
-const desktopDir = `${homeDir}/Desktop`;
+const desktopDir = path.join(homeDir, "Desktop");
 
 var window = null;
 var recordBtn = document.getElementById("record-all-btn");
@@ -46,7 +46,7 @@ export function getForkedProcess() {
 	const CHRONOSENSE_ROOT_DIR = path.join(path.resolve(__dirname), '../');
 	const POSTPROCESS_PATH = path.join(CHRONOSENSE_ROOT_DIR, 'JS_Files', 'postProcess.js');
 	forked = fork(POSTPROCESS_PATH);
-	console.log(forked);
+	// console.log(forked);
 	return forked;
 }
 

--- a/JS_Files/postProcess.js
+++ b/JS_Files/postProcess.js
@@ -7,7 +7,7 @@ const FFMPEG_DIR = path.join(CHRONOSENSE_ROOT_DIR, 'ffmpeg');
 
 process.on('message', (msg) => {
     let pp = null;
-    console.log('Message from parent:', msg);
+    // console.log('Message from parent:', msg);
     dirName = msg.dirName;
     fileName = msg.fileName;
     pp = new postProcesser(dirName, fileName)
@@ -25,8 +25,7 @@ class postProcesser {
     }
     postProcessVideoFile() {
         if (isWin) {
-            process.send("isWin true");
-            process.send(FFMPEG_DIR);
+            // process.send("isWin true");
             this.#c = spawn(path.join(FFMPEG_DIR,"ffmpeg.exe"), [
                 "-i",
                 path.join(this.#dirName, "raw", this.#fileName),
@@ -35,7 +34,7 @@ class postProcesser {
             process.send({ pid: this.#c.pid, child_state: "processing" });
         }
         else {
-            process.send("isWin false");
+            // process.send("isWin false");
             this.#c = spawn("ffmpeg", [
                 "-i",
                 '"'+path.join(this.#dirName, "raw", this.#fileName)+'"',
@@ -44,16 +43,16 @@ class postProcesser {
             process.send({ pid: this.#c.pid, child_state: "processing" });
         }
 
-        this.#c.stdout.on('data', (data) => {
-            process.send(`stdout: ${data}`);
-        });
+        // this.#c.stdout.on('data', (data) => {
+        //     process.send(`stdout: ${data}`);
+        // });
         
-        this.#c.stderr.on('data', (data) => {
-            process.send(`stderr: ${data}`);
-        });
+        // this.#c.stderr.on('data', (data) => {
+        //     process.send(`stderr: ${data}`);
+        // });
           
-        this.#c.on('close', () => {
-            process.send({ pid: this.#c.pid, child_state: "done" });
-        });
+        // this.#c.on('close', () => {
+        //     process.send({ pid: this.#c.pid, child_state: "done" });
+        // });
     }
 }

--- a/main.js
+++ b/main.js
@@ -30,7 +30,7 @@ function createWindow() {
     
     // // For debugging - show dev tool -> similar to chrome web browser tools (F12)
     // // ! Comment out before packaging as an executable !
-    mainWindow.webContents.openDevTools();
+    // mainWindow.webContents.openDevTools();
     
     //Close window when closed
     mainWindow.on('closed', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ChronoSense",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Chronosense Electron Application",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This PR merges in a number of changes to resolve issues around packaging and deploying ChronoSense across Windows and Mac OS. Specifically it implements usage of `path_fix@3.0` in order to resolve some issues with child_process spawning that is different between OS's to resolve #44 - @latest can not be used due to electron not supporting ESM natively.

Other quality of life improvements include changing the default recording directory to the current user's desktop as well as setting the recording directory to always be a timestamp when recording begins. NOTE if for some reason the desktop is not located at the default location a recording error may occur and current error handling does not make this obvious to the user. Created a new PR #46 to address this and implement other error handling.

Replaces all `.concat()` usage around pathing for the safer `path.join()` function

Finally includes version bump to v1.5.2 and audits vulnerabilities in npm.