### PR TITLE
stream logic cleanup for audio.js and matching to camera.js

### DIFF
--- a/JS_Files/camera.js
+++ b/JS_Files/camera.js
@@ -286,16 +286,12 @@ export class Camera {
 			})
 		}
 		try {
-			//if (this.#isVisible){
-				// Checking for false b/c true value is updated to false on click
-				if (!this.#audioCheckbox.checked){
-					// console.log("closing audio");
-					await this.closeAudioContext();
-				}
-			//}
+			if (this.#audioContext.state != "closed"){
+				await this.closeAudioContext();
+			}
 		}
 		catch {
-			console.log("camera not open");
+			console.log("audio not open");
 		}
 		//console.log("[camera.js:stopStream()] - Camera has been stopped");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ChronoSense",
-	"version": "1.6.0",
+	"version": "1.6.1",
 	"description": "Chronosense Electron Application",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This PR addresses issue #55 by streamlining the handling of `audioContext ` objects and associated streams by checking status and then closing any open streams appropriately in the `stopStreams()` function.

Cleans up both audio.js and camera.js where the same functions were being reused

Will release a bugfix version v1.6.1 when PR is merged