### PR TITLE
fix recordStatus for all device types

### DIFF
--- a/JS_Files/audio.js
+++ b/JS_Files/audio.js
@@ -55,8 +55,17 @@ export class Audio {
 	 *
 	 * @return {string} - Device identifier used to describe device output
 	 */
-	getKind() {
+	 getKind() {
 		return this.#kind;
+	}
+
+	/**
+	 * Getter function to retrieve the device recording status based on video and audio
+	 *
+	 * @return {string} - Device identifier used to describe device recording status
+	 */
+	getRecordStatus() {
+		return (this.#audioCheckbox.checked);
 	}
 
 	monitorAudio(stream) {

--- a/JS_Files/camera.js
+++ b/JS_Files/camera.js
@@ -70,8 +70,8 @@ export class Camera {
 	 *
 	 * @return {string} - Device identifier used to describe device recording status
 	 */
-		 getRecordStatus() {
-			return (this.#audioCheckbox.checked || this.#videoCheckbox.checked);
+	getRecordStatus() {
+		return (this.#audioCheckbox.checked || this.#videoCheckbox.checked);
 	}
 
 

--- a/JS_Files/chronosense.js
+++ b/JS_Files/chronosense.js
@@ -481,14 +481,11 @@ async function recordAllSelectedDevices() {
 			})
 			selectedDevices.forEach((device) => {
 				// Checks whether or not Audio or Video is selected if not do not start
-				if (device.getRecordStatus() == false) {
-					console.log('Audio and Video are both off')
-				}
-				else {
-				// Start recording
-				device.setDirName(recordDirectory);
-				device.startRecording();
-				numRecording++;
+				if (device.getRecordStatus()) {
+					// Start recording
+					device.setDirName(recordDirectory);
+					device.startRecording();
+					numRecording++;
 				}
 			});
 		}

--- a/JS_Files/chronosense.js
+++ b/JS_Files/chronosense.js
@@ -472,7 +472,7 @@ async function recordAllSelectedDevices() {
 			// Prevents the user from recording any devices if screen capture is not selected
 			// Looks through all devices before attempting to record to check if there is a null screen capture
 			selectedDevices.forEach((device) => {
-				if(device.getLabel() == "Screen Capture") {
+				if(device.getLabel() == "ScreenCapture") {
 					if(device.getScreenCaptureStatus() == null) {
 						swal("Select a screen to record")
 						throw new Error('Select a screen to record')

--- a/JS_Files/screen_capture_device.js
+++ b/JS_Files/screen_capture_device.js
@@ -2,9 +2,10 @@ const remote = require('@electron/remote');
 import { AVRecorder } from './avRecorder.js';
 
 export class ScreenCaptureDevice {
-
-    #label = "Screen Capture";
-    #deviceId = "ScreenCaptureModule";
+	#deviceId = "ScreenCapture";
+	#groupId = "ScreenCapture";
+	#kind = "screencapture";
+	#label = "ScreenCapture";
 	#videoElement = null;
 	#optionContainer = null;
 	#sources = []
@@ -27,10 +28,51 @@ export class ScreenCaptureDevice {
 	/**
 	 * Constructor for a ScreenCaptureDevice object that captures stream of video/audio from user screens & windows.
 	 *
+	 * @param {string} deviceId - Identifier for the device used in input capture.
+	 * @param {string} groupId - Identifier for the device group used in input capture.
+	 * @param {string} kind - Identifier for type of input from device.
+	 * @param {string} label - Name Identifier (Sensical to user for reading).
 	 */
-    constructor() {
-        this.getCaptureSources();
-    }
+	constructor(deviceId, groupId, kind, label) {
+		this.#deviceId = "ScreenCapture";
+		this.#groupId = "ScreenCapture";
+		this.#kind = "screencapture";
+		this.#label = "ScreenCapture";
+
+		this.getCaptureSources();
+	}
+
+	getPluginDiv() {
+		let _pluginDiv = this.#pluginDiv;
+		return _pluginDiv;
+	}
+
+	/**
+	 * Getter function to retrieve the object's Group ID
+	 *
+	 * @return {string} - Group identifier used to connect it to other similar devices
+	 */
+	getGroupId() {
+		return this.#groupId;
+	}
+
+	/**
+	 * Getter function to retrieve the object's "kind"
+	 *
+	 * @return {string} - Device identifier used to describe device output
+	 */
+	getKind() {
+		return this.#kind;
+	}
+
+	/**
+	 * Getter function to retrieve the device recording status based on video and audio
+	 *
+	 * @return {string} - Device identifier used to describe device recording status
+	 */
+	getRecordStatus() {
+		return (this.#videoCheckbox.checked);
+	}
 
 	fixForMacOS() {
 		if(process.platform === "darwin") {
@@ -45,6 +87,8 @@ export class ScreenCaptureDevice {
 		let _pluginDiv = this.#pluginDiv;
 		return _pluginDiv;
 	}
+
+
 
 	/**
 	 * Collects all of the possible screen and window sources into an array for later use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "ChronoSense",
-	"version": "1.7.3",
+	"version": "1.7.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ChronoSense",
-	"version": "1.7.3",
+	"version": "1.7.4",
 	"description": "Chronosense Electron Application",
 	"main": "main.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"start": "electron-forge start",
 		"make": "electron-forge make",
-		"publish": "electron-forge publish"
+		"publish": "electron-forge publish",
+		"postinstall": "node get_ffmpeg.js"
 	},
 	"author": "WeibelLab",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
Noted that the screenCapture device type did not support getRecordStatus() so addressed this and other cleanup related to cross-device consistency